### PR TITLE
Addresses a PHP Fatal Error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -26,16 +26,19 @@ if ( defined( 'WP_CLI' ) ) {
 }
 
 function wpimportv2_init() {
-	/**
-	 * WordPress Importer object for registering the import callback
-	 * @global WP_Import $wp_import
-	 */
-	$GLOBALS['wp_import_v2'] = new WP_Import();
-	register_importer(
-		'wordpress-v2',
-		'WordPress (v2)',
-		__('Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'wordpress-importer'),
-		array( $GLOBALS['wp_import'], 'dispatch' )
-	);
+	// Bail if `WP_Import doesn't exist.
+	if ( class_exists( 'WP_Import' ) ) {
+		/**
+		 * WordPress Importer object for registering the import callback
+		 * @global WP_Import $wp_import
+		 */
+		$GLOBALS['wp_import_v2'] = new WP_Import();
+		register_importer(
+			'wordpress-v2',
+			'WordPress (v2)',
+			__('Import <strong>posts, pages, comments, custom fields, categories, and tags</strong> from a WordPress export file.', 'wordpress-importer'),
+			array( $GLOBALS['wp_import'], 'dispatch' )
+		);
+	}
 }
 add_action( 'admin_init', 'wpimportv2_init' );


### PR DESCRIPTION
Addresses the PHP fatal error due to absence of `WP_Import()` class.

![](https://i.imgur.com/Vaclzvw.png)