### PR TITLE
Fix invalid number of items to progress

### DIFF
--- a/assets/import.js
+++ b/assets/import.js
@@ -19,10 +19,11 @@
 		updateProgress: function ( type, complete, total ) {
 			var text = complete + '/' + total;
 			document.getElementById( 'completed-' + type ).innerHTML = text;
+      total = parseInt( total );
       if ( 0 == total ) {
         total = 1;
       }
-  		var percent = parseInt( complete ) / parseInt( total );
+  		var percent = parseInt( complete ) / total;
 			document.getElementById( 'progress-' + type ).innerHTML = Math.round( percent * 100 ) + '%';
 			document.getElementById( 'progressbar-' + type ).value = percent * 100;
 		},

--- a/assets/import.js
+++ b/assets/import.js
@@ -19,11 +19,11 @@
 		updateProgress: function ( type, complete, total ) {
 			var text = complete + '/' + total;
 			document.getElementById( 'completed-' + type ).innerHTML = text;
-      total = parseInt( total );
-      if ( 0 == total ) {
-        total = 1;
-      }
-  		var percent = parseInt( complete ) / total;
+			total = parseInt( total, 10 );
+			if ( 0 === total || isNan( total ) {
+				total = 1;
+			}
+			var percent = parseInt( complete, 10 ) / total;
 			document.getElementById( 'progress-' + type ).innerHTML = Math.round( percent * 100 ) + '%';
 			document.getElementById( 'progressbar-' + type ).value = percent * 100;
 		},

--- a/assets/import.js
+++ b/assets/import.js
@@ -19,7 +19,10 @@
 		updateProgress: function ( type, complete, total ) {
 			var text = complete + '/' + total;
 			document.getElementById( 'completed-' + type ).innerHTML = text;
-			var percent = parseInt( complete ) / parseInt( total );
+      if ( 0 == total ) {
+        total = 1;
+      }
+  		var percent = parseInt( complete ) / parseInt( total );
 			document.getElementById( 'progress-' + type ).innerHTML = Math.round( percent * 100 ) + '%';
 			document.getElementById( 'progressbar-' + type ).value = percent * 100;
 		},

--- a/assets/import.js
+++ b/assets/import.js
@@ -20,7 +20,7 @@
 			var text = complete + '/' + total;
 			document.getElementById( 'completed-' + type ).innerHTML = text;
 			total = parseInt( total, 10 );
-			if ( 0 === total || isNan( total ) {
+			if ( 0 === total || isNaN( total ) ) {
 				total = 1;
 			}
 			var percent = parseInt( complete, 10 ) / total;


### PR DESCRIPTION
When the total number of items to process is 0 then the calculation of the percentage complete produces an Uncaught TypeError and the JavaScript stops. 

This change sets the total to 1 if it would have been 0, either due to it not being numeric or it actually being 0. The percentage will show as 0% but the importing will continue;

Fixes #40