### PR TITLE
Post terms set with incorrect parameter type

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -902,7 +902,7 @@ class WXR_Importer extends WP_Importer {
 				$key = sha1( $taxonomy . ':' . $term['slug'] );
 
 				if ( isset( $this->mapping['term'][ $key ] ) ) {
-					$term_ids[ $taxonomy ][] = $this->mapping['term'][ $key ];
+					$term_ids[ $taxonomy ][] = (int) $this->mapping['term'][ $key ];
 				}
 				else {
 					$meta[] = array( 'key' => '_wxr_import_term', 'value' => $term );


### PR DESCRIPTION
I'm developing a plugin which is using this new WP importer and I came across a small issue in the code... The issue is that when I make the import with multiple AJAX calls the menu items import under new menus, which use the IDs of the menus that they are supposed to import into:
<img width="298" alt="menu-items-import-error" src="https://cloud.githubusercontent.com/assets/9714134/15097251/0341c2ae-1516-11e6-8911-eb2bc1b549f0.png">

The fix:
You are using the WP function `wp_set_post_terms`, in which the second parameter is [not passed correctly](https://codex.wordpress.org/Function_Reference/wp_set_post_terms#Notes). The id should be an integer, but a string is passed instead. Simply type casting it to `int`, solves the issue.