### PR TITLE
Old and new importer plugins can't both be activated since they now h…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fast, lightweight, consistent. Pick three. :palm_tree: :sunglasses:
 ### Via the Dashboard
 
 1. Install the plugin directly from GitHub. ([Download as a ZIP.](https://github.com/humanmade/WordPress-Importer/archive/master.zip))
-2. Activate the plugin.
+2. Activate the plugin (make sure you also deactivate the original Wordpress Importer if you have it installed).
 3. Head to Tools &rarr; Import
 4. Select "WordPress (v2)"
 5. Follow the on-screen instructions.


### PR DESCRIPTION
…ave the same slug name.

The slug name was changed from "wordpress-v2" to just "wordpress" in 887fd5ba0135e70228c6b6406f86d9259546b6df. As a result, having both old and new plugins activated causes the new version to not appear and the old version to not work.