### PR TITLE
Draft implementation of terms import for term-parent slug and term meta

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1860,11 +1860,11 @@ class WXR_Importer extends WP_Importer {
 
 			$data = array();
 
-			$parent = get_post_meta( $post_id, '_wxr_import_parent', true );
-			if ( ! empty( $parent ) ) {
+			$parent_id = get_post_meta( $post_id, '_wxr_import_parent', true );
+			if ( ! empty( $parent_id ) ) {
 				// Have we imported the parent now?
-				if ( isset( $this->mapping['post'][ $parent ] ) ) {
-					$data['post_parent'] = $this->mapping['post'][ $parent ];
+				if ( isset( $this->mapping['post'][ $parent_id ] ) ) {
+					$data['post_parent'] = $this->mapping['post'][ $parent_id ];
 				} else {
 					$this->logger->warning( sprintf(
 						__( 'Could not find the post parent for "%s" (post #%d)', 'wordpress-importer' ),
@@ -1874,7 +1874,7 @@ class WXR_Importer extends WP_Importer {
 					$this->logger->debug( sprintf(
 						__( 'Post %d was imported with parent %d, but could not be found', 'wordpress-importer' ),
 						$post_id,
-						$parent
+						$parent_id
 					) );
 				}
 			}
@@ -2089,11 +2089,11 @@ class WXR_Importer extends WP_Importer {
 		foreach ( $todo as $comment_id => $_ ) {
 			$data = array();
 
-			$parent = get_comment_meta( $comment_id, '_wxr_import_parent', true );
+			$parent_id = get_comment_meta( $comment_id, '_wxr_import_parent', true );
 			if ( ! empty( $parent ) ) {
 				// Have we imported the parent now?
-				if ( isset( $this->mapping['comment'][ $parent ] ) ) {
-					$data['comment_parent'] = $this->mapping['comment'][ $parent ];
+				if ( isset( $this->mapping['comment'][ $parent_id ] ) ) {
+					$data['comment_parent'] = $this->mapping['comment'][ $parent_id ];
 				} else {
 					$this->logger->warning( sprintf(
 						__( 'Could not find the comment parent for comment #%d', 'wordpress-importer' ),
@@ -2102,7 +2102,7 @@ class WXR_Importer extends WP_Importer {
 					$this->logger->debug( sprintf(
 						__( 'Comment %d was imported with parent %d, but could not be found', 'wordpress-importer' ),
 						$comment_id,
-						$parent
+						$parent_id
 					) );
 				}
 			}

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1556,15 +1556,12 @@ class WXR_Importer extends WP_Importer {
 		do_action( 'wxr_importer.processed.user', $user_id, $userdata );
 	}
 
-/**
-	 * Output termmeta XML tags for a given term object.
-	 *
-	 * @since 4.6.0
-	 *
-	 * @param WP_Term $term Term object.
+/** Output termmeta XML tags for a given term object.
+ * @since 4.6.0
+ * @param WP_Term $term Term object.
 **/
-/*
-	function wxr_term_meta( $term ) {
+
+/*	function wxr_term_meta( $term ) {
 		global $wpdb;
 
 		$termmeta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->termmeta WHERE term_id = %d", $term->term_id ) );
@@ -1600,6 +1597,7 @@ class WXR_Importer extends WP_Importer {
 			'parent'      => 'wp:term_parent',
 			'name'        => 'wp:term_name',
 			'description' => 'wp:term_description',
+			'meta'        => 'wp:termmeta',
 		);
 		$taxonomy = null;
 
@@ -1611,6 +1609,7 @@ class WXR_Importer extends WP_Importer {
 				$tag_name['name']        = 'wp:cat_name';
 				$tag_name['description'] = 'wp:category_description';
 				$tag_name['taxonomy']    = null;
+				$tag_name['meta']        =  'wp:termmeta';
 
 				$data['taxonomy'] = 'category';
 				break;
@@ -1621,6 +1620,7 @@ class WXR_Importer extends WP_Importer {
 				$tag_name['name']        = 'wp:tag_name';
 				$tag_name['description'] = 'wp:tag_description';
 				$tag_name['taxonomy']    = null;
+				$tag_name['meta']        =  'wp:termmeta';
 
 				$data['taxonomy'] = 'post_tag';
 				break;

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1562,7 +1562,8 @@ class WXR_Importer extends WP_Importer {
 	 * @since 4.6.0
 	 *
 	 * @param WP_Term $term Term object.
-	 
+**/
+/*
 	function wxr_term_meta( $term ) {
 		global $wpdb;
 
@@ -1585,7 +1586,7 @@ class WXR_Importer extends WP_Importer {
 			}
 		}
 	}
-	*/
+*/
 
 
 	protected function parse_term_node( $node, $type = 'term' ) {

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1556,6 +1556,39 @@ class WXR_Importer extends WP_Importer {
 		do_action( 'wxr_importer.processed.user', $user_id, $userdata );
 	}
 
+/**
+	 * Output termmeta XML tags for a given term object.
+	 *
+	 * @since 4.6.0
+	 *
+	 * @param WP_Term $term Term object.
+	 
+	function wxr_term_meta( $term ) {
+		global $wpdb;
+
+		$termmeta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->termmeta WHERE term_id = %d", $term->term_id ) );
+
+		foreach ( $termmeta as $meta ) {
+			/**
+			 * Filter whether to selectively skip term meta used for WXR exports.
+			 *
+			 * Returning a truthy value to the filter will skip the current meta
+			 * object from being exported.
+			 *
+			 * @since 4.6.0
+			 *
+			 * @param bool   $skip     Whether to skip the current piece of term meta. Default false.
+			 * @param string $meta_key Current meta key.
+			 * @param object $meta     Current meta object.
+			 */
+			if ( ! apply_filters( 'wxr_export_skip_termmeta', false, $meta->meta_key, $meta ) ) {
+				printf( "\t\t<wp:termmeta>\n\t\t\t<wp:meta_key>%s</wp:meta_key>\n\t\t\t<wp:meta_value>%s</wp:meta_value>\n\t\t</wp:termmeta>\n", wxr_cdata( $meta->meta_key ), wxr_cdata( $meta->meta_value ) );
+			}
+		}
+	}
+	*/
+
+
 	protected function parse_term_node( $node, $type = 'term' ) {
 		$data = array();
 		$meta = array();

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1304,6 +1304,7 @@ class WXR_Importer extends WP_Importer {
 			'meta'        => 'wp:termmeta',
 		);
 		$taxonomy = null;
+		$data['meta'] = array();
 		// Special casing!
 		switch ( $type ) {
 			case 'category':
@@ -1333,12 +1334,8 @@ class WXR_Importer extends WP_Importer {
 // Debug::log("In class-wxr-importer, function parse_term_node, about to parse termmeta node: " . print_r($child ,true));
 				$result = $this->parse_meta_node( $child );
 // Debug::log("In class-wxr-importer, function parse_term_node, parsed termmeta result: " . print_r($result ,true));			
- 				if(!empty($result)){
-					$newkey = $result['key'];
-// Debug::log("In class-wxr-importer, function parse_term_node, newkey: ". print_r($newkey,true));
-					$newvalue = $result['value'];
-// Debug::log("In class-wxr-importer, function parse_term_node, newvalue: ". print_r($newvalue,true));
-					$meta[$newkey] = $newvalue;
+ 				if(!empty($result) && isset($result['key']) && isset($result['value'])){
+					$data['meta'][$result['key']] = $result['value'];
 				}
 // Debug::log("In class-wxr-importer, function parse_term_node, merged local meta array: " . print_r($meta,true));
 				continue;	
@@ -1395,9 +1392,9 @@ class WXR_Importer extends WP_Importer {
 			'description' => true,
 		);
 
-		// Map the parent comment, or mark it as one we need to fix
+		// Map the parent term, or mark it as one we need to fix
 		// TODO: add parent mapping and remapping
-		/*$requires_remapping = false;
+		$requires_remapping = false;
 		if ( $parent_id ) {
 			if ( isset( $this->mapping['term'][ $parent_id ] ) ) {
 				$data['parent'] = $this->mapping['term'][ $parent_id ];
@@ -1409,7 +1406,7 @@ class WXR_Importer extends WP_Importer {
 				// Wipe the parent for now
 				$data['parent'] = 0;
 			}
-		}*/
+		}
 
 		foreach ( $data as $key => $value ) {
 			if ( ! isset( $allowed[ $key ] ) ) {
@@ -1450,8 +1447,8 @@ class WXR_Importer extends WP_Importer {
 				/* TRY 2016-08-20 */
 		/* insert termmeta, if any */
 // Debug::log("In class-wxr-importer, function process_term, successfully added term_id: " . $term_id . "with associated meta: " . print_r($meta,true));
-		if(!empty($meta)){
-			foreach ($meta as $meta_key => $meta_value){
+		if(isset($data['meta'])){
+			foreach ($data['meta'] as $meta_key => $meta_value){
 // Debug::log("In class-wxr-importer, function process_term, about to insert meta_key: " . print_r($meta_key,true));
 				 $result = add_term_meta ($term_id, $meta_key, $meta_value) ;
 				 if ( is_wp_error( $result ) ) {

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1757,7 +1757,6 @@ Debug::log("In class-wxr-importer, function parse_term_node, skipping over node:
 			$result = wp_update_term( $term_id, $termattributes['taxonomy'], $termattributes );
 			
 			if ( is_wp_error( $result ) ) {
-Debug::log("Failed to update term: " . $term_id . ", because of error: " . $result->get_error_message());
 			$this->logger->warning( sprintf(
 					__( 'Could not update "%s" (term #%d) with mapped data', 'wordpress-importer' ),
 					$termattributes['name'],
@@ -1770,7 +1769,6 @@ Debug::log("Failed to update term: " . $term_id . ", because of error: " . $resu
 			// Clear out our temporary meta key
 			delete_term_meta( $term_id, '_wxr_import_parent' );
 
-Debug::log("In class-wxr-importer, function post_process_terms, successfully updated term: " . print_r($result,true) . ", with new data: ".print_r($termattributes,true));
 			$this->logger->debug( sprintf(
 				__( 'Term %d was successfully updated with parent %d', 'wordpress-importer' ),
 				$term_id,

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1569,18 +1569,17 @@ class WXR_Importer extends WP_Importer {
 		$termmeta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->termmeta WHERE term_id = %d", $term->term_id ) );
 
 		foreach ( $termmeta as $meta ) {
-			/**
-			 * Filter whether to selectively skip term meta used for WXR exports.
-			 *
-			 * Returning a truthy value to the filter will skip the current meta
-			 * object from being exported.
-			 *
-			 * @since 4.6.0
-			 *
-			 * @param bool   $skip     Whether to skip the current piece of term meta. Default false.
-			 * @param string $meta_key Current meta key.
-			 * @param object $meta     Current meta object.
-			 */
+			 // Filter whether to selectively skip term meta used for WXR exports.
+			 //
+			 // Returning a truthy value to the filter will skip the current meta
+			 // object from being exported.
+			 //
+			 // @since 4.6.0
+			 //
+			 // @param bool   $skip     Whether to skip the current piece of term meta. Default false.
+			 // @param string $meta_key Current meta key.
+			 // @param object $meta     Current meta object.
+			 //
 			if ( ! apply_filters( 'wxr_export_skip_termmeta', false, $meta->meta_key, $meta ) ) {
 				printf( "\t\t<wp:termmeta>\n\t\t\t<wp:meta_key>%s</wp:meta_key>\n\t\t\t<wp:meta_value>%s</wp:meta_value>\n\t\t</wp:termmeta>\n", wxr_cdata( $meta->meta_key ), wxr_cdata( $meta->meta_value ) );
 			}

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1324,26 +1324,15 @@ class WXR_Importer extends WP_Importer {
 		foreach ( $node->childNodes as $child ) {
 			// We only care about child elements
 			if ( $child->nodeType !== XML_ELEMENT_NODE ) {
-if ( $child->nodeType === XML_TEXT_NODE ){ //Debug::log("In class-wxr-importer, function parse_term_node, skipping over text node.");
-continue;
-}
-if ( $child->nodeType === XML_CDATA_SECTION_NODE ){ Debug::log("In class-wxr-importer, function parse_term_node, skipping over CDATA node.");
-continue;
-}
-Debug::log("In class-wxr-importer, function parse_term_node, skipping over node: " . print_r($child,true));
 				continue;
 			}
-			/* TRY 2016-07-21 */
+
 			if ($child->tagName=='wp:termmeta'){
-//Debug::log("In class-wxr-importer, function parse_term_node, about to parse termmeta node: " . print_r($child ,true));
 				$result = $this->parse_meta_node( $child );
-// Debug::log("In class-wxr-importer, function parse_term_node, parsed termmeta result: " . print_r($result ,true));			
  				if(!empty($result) && isset($result['key']) && isset($result['value'])){
 					$meta[$result['key']] = $result['value'];
 				}
-// Debug::log("In class-wxr-importer, function parse_term_node, merged local meta array: " . print_r($meta,true));
 			}
-// Debug::log("In class-wxr-importer, function parse_term_node, " . );
 
 			$key = array_search( $child->tagName, $tag_name );
 			if ( $key ) {

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -2090,7 +2090,7 @@ class WXR_Importer extends WP_Importer {
 			$data = array();
 
 			$parent_id = get_comment_meta( $comment_id, '_wxr_import_parent', true );
-			if ( ! empty( $parent ) ) {
+			if ( ! empty( $parent_id ) ) {
 				// Have we imported the parent now?
 				if ( isset( $this->mapping['comment'][ $parent_id ] ) ) {
 					$data['comment_parent'] = $this->mapping['comment'][ $parent_id ];

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1609,7 +1609,6 @@ class WXR_Importer extends WP_Importer {
 				$tag_name['name']        = 'wp:cat_name';
 				$tag_name['description'] = 'wp:category_description';
 				$tag_name['taxonomy']    = null;
-				$tag_name['meta']        =  'wp:termmeta';
 
 				$data['taxonomy'] = 'category';
 				break;
@@ -1620,7 +1619,6 @@ class WXR_Importer extends WP_Importer {
 				$tag_name['name']        = 'wp:tag_name';
 				$tag_name['description'] = 'wp:tag_description';
 				$tag_name['taxonomy']    = null;
-				$tag_name['meta']        =  'wp:termmeta';
 
 				$data['taxonomy'] = 'post_tag';
 				break;
@@ -1632,6 +1630,15 @@ class WXR_Importer extends WP_Importer {
 				continue;
 			}
 
+			/* TRY 2016-07-21 */
+			if $child->tagName=='wp:termmeta'){
+/* parse a meta node into meta data.
+*
+* @param DOMElement $node Parent node of meta data (typically `wp:postmeta` or `wp:commentmeta`).
+* @return array|null Meta data array on success, or null on error.				
+ */
+				continue;	
+			}
 			$key = array_search( $child->tagName, $tag_name );
 			if ( $key ) {
 				$data[ $key ] = $child->textContent;
@@ -1704,9 +1711,6 @@ class WXR_Importer extends WP_Importer {
 			if ( ! isset( $allowed[ $key ] ) ) {
 				continue;
 			}
-
-			$termdata[ $key ] = $data[ $key ];
-		}
 
 		$result = wp_insert_term( $data['name'], $data['taxonomy'], $termdata );
 		if ( is_wp_error( $result ) ) {

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1632,11 +1632,7 @@ class WXR_Importer extends WP_Importer {
 
 			/* TRY 2016-07-21 */
 			if $child->tagName=='wp:termmeta'){
-/* parse a meta node into meta data.
-*
-* @param DOMElement $node Parent node of meta data (typically `wp:postmeta` or `wp:commentmeta`).
-* @return array|null Meta data array on success, or null on error.				
- */
+ 				$meta = array_merge($meta, parse_meta_node( $child ) );
 				continue;	
 			}
 			$key = array_search( $child->tagName, $tag_name );
@@ -1750,6 +1746,23 @@ class WXR_Importer extends WP_Importer {
 		) );
 
 		do_action( 'wp_import_insert_term', $term_id, $data );
+		
+		/* TRY 2016-08-20 */
+		/* insert termmeta, if any */
+		if(!empty($meta)){
+			foreach ($meta as $meta_key => $meta_value){
+				 $result = add_term_meta ($term_id, $meta_key, $meta_value) ;
+				 if ( is_wp_error( $result ) ) {
+					$this->logger->warning( sprintf(
+						__( 'Failed to add metakey: %s, metavalue: %s to term_id: %d', 'wordpress-importer' ),
+						 $meta_key, $meta_value,$term_id) );
+				 } else {
+					$this->logger->debug( sprintf(
+						__( 'Meta for term_id %d : %s => %s ; successfully added!', 'wordpress-importer' ),
+						$term_id, $meta_key, $meta_value) );
+				}
+			}
+		}
 
 		/**
 		 * Term processing completed.


### PR DESCRIPTION
Just discovered this version 2 of the WordPress Importer, it is a great improvement over v1!

My site (4.5.3) makes extensive usage of hierarchical terms and of term-meta.
It seems that the v4.5 (maybe earlier) export.php will exports a parent slug, rather than an integer ID.

I took the liberty of drafting some code to implement term parentage and term meta.

The attached diff seems to correctly remap an export with a slug for a term parent.
(I always got a slug with my term exports, never an integer. This diff handles everything in the parent element as a string, e.g <wp:category_parent>STRING</wp:category_parent> )

This diff also will upload term-meta, including multiple <wp:termmeta/> elements within the same term.

This diff has been tested only for category, not tags or other taxonomies.

(warning: I haven't submitted a request for any project in many years! ;-)
Thank you! -Don

[class-wxr-importer.diff.txt](https://github.com/humanmade/WordPress-Importer/files/379976/class-wxr-importer.diff.txt)

