### PR TITLE
Icrement progress delta when skipped / already imported items are processed

### DIFF
--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -457,10 +457,13 @@ class WXR_Import_UI {
 		// Keep track of our progress
 		add_action( 'wxr_importer.processed.post', array( $this, 'imported_post' ), 10, 2 );
 		add_action( 'wxr_importer.process_failed.post', array( $this, 'imported_post' ), 10, 2 );
+		add_action( 'wxr_importer.process_already_imported.post', array( $this, 'already_imported_post' ), 10, 2 );
 		add_action( 'wxr_importer.process_skipped.post', array( $this, 'already_imported_post' ), 10, 2 );
 		add_action( 'wxr_importer.processed.comment', array( $this, 'imported_comment' ) );
+		add_action( 'wxr_importer.process_already_imported.comment', array( $this, 'imported_comment' ) );
 		add_action( 'wxr_importer.processed.term', array( $this, 'imported_term' ) );
 		add_action( 'wxr_importer.process_failed.term', array( $this, 'imported_term' ) );
+		add_action( 'wxr_importer.process_already_imported.term', array( $this, 'imported_term' ) );
 		add_action( 'wxr_importer.processed.user', array( $this, 'imported_user' ) );
 		add_action( 'wxr_importer.process_failed.user', array( $this, 'imported_user' ) );
 

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -457,6 +457,7 @@ class WXR_Import_UI {
 		// Keep track of our progress
 		add_action( 'wxr_importer.processed.post', array( $this, 'imported_post' ), 10, 2 );
 		add_action( 'wxr_importer.process_failed.post', array( $this, 'imported_post' ), 10, 2 );
+		add_action( 'wxr_importer.process_skipped.post', array( $this, 'already_imported_post' ), 10, 2 );
 		add_action( 'wxr_importer.processed.comment', array( $this, 'imported_comment' ) );
 		add_action( 'wxr_importer.processed.term', array( $this, 'imported_term' ) );
 		add_action( 'wxr_importer.process_failed.term', array( $this, 'imported_term' ) );
@@ -681,6 +682,19 @@ class WXR_Import_UI {
 	 * @param array $data Post data saved to the DB.
 	 */
 	public function imported_post( $id, $data ) {
+		$this->emit_sse_message( array(
+			'action' => 'updateDelta',
+			'type'   => ( $data['post_type'] === 'attachment' ) ? 'media' : 'posts',
+			'delta'  => 1,
+		));
+	}
+
+	/**
+	 * Send message when a post is marked as already imported.
+	 *
+	 * @param array $data Post data saved to the DB.
+	 */
+	public function already_imported_post( $data ) {
 		$this->emit_sse_message( array(
 			'action' => 'updateDelta',
 			'type'   => ( $data['post_type'] === 'attachment' ) ? 'media' : 'posts',

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -765,6 +765,13 @@ class WXR_Importer extends WP_Importer {
 				$data['post_title']
 			) );
 
+			/**
+			 * Post processing already imported.
+			 *
+			 * @param array $data Raw data imported for the post.
+			 */
+			do_action( 'wxr_importer.process_already_imported.post', $data );
+
 			// Even though this post already exists, new comments might need importing
 			$this->process_comments( $comments, $original_id, $data, $post_exists );
 
@@ -1291,6 +1298,14 @@ class WXR_Importer extends WP_Importer {
 			if ( $post_exists ) {
 				$existing = $this->comment_exists( $comment );
 				if ( $existing ) {
+
+					/**
+					 * Comment processing already imported.
+					 *
+					 * @param array $comment Raw data imported for the comment.
+					 */
+					do_action( 'wxr_importer.process_already_imported.comment', $comment );
+
 					$this->mapping['comment'][ $original_id ] = $exists;
 					continue;
 				}
@@ -1642,6 +1657,14 @@ class WXR_Importer extends WP_Importer {
 		$mapping_key = sha1( $data['taxonomy'] . ':' . $data['slug'] );
 		$existing = $this->term_exists( $data );
 		if ( $existing ) {
+
+			/**
+			 * Term processing already imported.
+			 *
+			 * @param array $data Raw data imported for the term.
+			 */
+			do_action( 'wxr_importer.process_already_imported.term', $data );
+
 			$this->mapping['term'][ $mapping_key ] = $existing;
 			$this->mapping['term_id'][ $original_id ] = $existing;
 			return false;

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -841,6 +841,13 @@ class WXR_Importer extends WP_Importer {
 					__( 'Skipping attachment "%s", fetching attachments disabled' ),
 					$data['post_title']
 				) );
+				/**
+				 * Post processing skipped.
+				 *
+				 * @param array $data Raw data imported for the post.
+				 * @param array $meta Raw meta data, already processed by {@see process_post_meta}.
+				 */
+				do_action( 'wxr_importer.process_skipped.post', $data, $meta );
 				return false;
 			}
 			$remote_url = ! empty( $data['attachment_url'] ) ? $data['attachment_url'] : $data['guid'];


### PR DESCRIPTION
Current the UI does not show all processed if there are items that were skipped / already imported. Instead we should fire looks at the UI class can use a hints to update.
