### PR TITLE
Enable XML files to be selected in files dialogue

### DIFF
--- a/assets/intro.css
+++ b/assets/intro.css
@@ -8,3 +8,8 @@
 	width: 200px;
 	margin: 0 auto;
 }
+
+/* TODO: keep an eye out for a better way to remove the upload tab */
+#import-select .media-router a:not(.active) {
+	display: none;
+}

--- a/assets/intro.css
+++ b/assets/intro.css
@@ -8,8 +8,3 @@
 	width: 200px;
 	margin: 0 auto;
 }
-
-/* TODO: keep an eye out for a better way to remove the upload tab */
-#import-select .media-router a:not(.active) {
-	display: none;
-}

--- a/assets/intro.js
+++ b/assets/intro.js
@@ -85,10 +85,12 @@
 
 		// Create the media frame.
 		var frame = wp.media({
+			id: 'import-select',
 			// Set the title of the modal.
-			title: "Select",
+			title: options.l10n.frameTitle,
+			multiple: true,
 
-			// Tell the modal to show only images.
+			// Tell the modal to show only xml files.
 			library: {
 				type: '',
 				status: 'private',
@@ -97,7 +99,7 @@
 			// Customize the submit button.
 			button: {
 				// Set the text of the button.
-				text: "Import",
+				text: options.l10n.buttonText,
 				// Tell the button not to close the modal, since we're
 				// going to refresh the page when the image is selected.
 				close: false,

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -154,10 +154,24 @@ class WXR_Import_UI {
 		// Set uploader settings
 		wp_plupload_default_settings();
 		$settings = array(
+			'l10n' => array(
+				'frameTitle' => esc_html__( 'Select', 'wordpress-importer' ),
+				'buttonText' => esc_html__( 'Import', 'wordpress-importer' ),
+			),
 			'next_url' => wp_nonce_url( $this->get_url( 1 ), 'import-upload' ) . '&id={id}',
 			'plupload' => array(
-				'filter' => array(
+				'filters' => array(
 					'max_file_size' => $max_upload_size . 'b',
+					'mime_types'    => array(
+						array(
+							'title' => esc_html__( 'Zip files', 'wordpress-importer' ),
+							'extensions' => 'zip'
+						),
+						array(
+							'title' => esc_html__( 'XML files', 'wordpress-importer' ),
+							'extensions' => 'xml'
+						)
+					)
 				),
 
 				'file_data_name' => 'import',

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -164,10 +164,6 @@ class WXR_Import_UI {
 					'max_file_size' => $max_upload_size . 'b',
 					'mime_types'    => array(
 						array(
-							'title' => esc_html__( 'Zip files', 'wordpress-importer' ),
-							'extensions' => 'zip'
-						),
-						array(
 							'title' => esc_html__( 'XML files', 'wordpress-importer' ),
 							'extensions' => 'xml'
 						)

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -164,10 +164,10 @@ class WXR_Import_UI {
 					'max_file_size' => $max_upload_size . 'b',
 					'mime_types'    => array(
 						array(
-							'title' => esc_html__( 'XML files', 'wordpress-importer' ),
-							'extensions' => 'xml'
-						)
-					)
+							'title'      => esc_html__( 'XML files', 'wordpress-importer' ),
+							'extensions' => 'xml',
+						),
+					),
 				),
 
 				'file_data_name' => 'import',

--- a/templates/upload.php
+++ b/templates/upload.php
@@ -76,7 +76,7 @@
 	<# } else { #>
 
 		<p><?php esc_html_e( 'Success! Your import file is ready, let&#8217;s get started.', 'wordpress-importer' ) ?></p>
-		<p><button type="submit" class="button"><?php esc_html_e( 'Start Import', 'wordpress-importer' ) ?></a></p>
+		<p><button type="submit" class="button"><?php esc_html_e( 'Start Import', 'wordpress-importer' ) ?></button></p>
 
 	<# } #>
 </script>


### PR DESCRIPTION
A feature of plupload is to set the mime types expected. This makes sure only xml files can be selected via the plupload popup.

Fixes #49