### PR TITLE
Adds .xml to allowed mime types & improves "Import Completed" notice appearance.

### DIFF
--- a/assets/import.css
+++ b/assets/import.css
@@ -42,7 +42,6 @@
 #completed-total {
 	display: none;
 }
-
 #import-status-message {
 	border-top: 1px solid #f2f2f2;
 	height: 40px;

--- a/assets/import.css
+++ b/assets/import.css
@@ -42,3 +42,10 @@
 #completed-total {
 	display: none;
 }
+
+#import-status-message {
+	border-top: 1px solid #f2f2f2;
+	height: 40px;
+	line-height: 40px;
+	margin: 20px 0;
+}

--- a/assets/import.js
+++ b/assets/import.js
@@ -56,7 +56,10 @@
 
 			case 'complete':
 				evtSource.close();
-				jQuery('#import-status-message').text( wxrImport.data.strings.complete );
+				var import_status_msg = jQuery('#import-status-message');
+				import_status_msg.text( wxrImport.data.strings.complete );
+				import_status_msg.removeClass('notice-info');
+				import_status_msg.addClass('notice-success');
 				break;
 		}
 	};

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -26,7 +26,7 @@ class WXR_Import_UI {
 	 * @param array $mimes Already supported mime types.
 	 */
 	function add_mime_type_xml( $mimes ) {
-			$mimes = array_merge( $mimes, array('xml' => 'application/xml') );
+			$mimes = array_merge( $mimes, array( 'xml' => 'application/xml' ) );
 			return $mimes;
 	}
 

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -26,11 +26,9 @@ class WXR_Import_UI {
 	 * @param array $mimes Already supported mime types.
 	 */
 	public function add_mime_type_xml( $mimes ) {
-			$mimes = array_merge( $mimes, array(
-				'xml' => 'application/xml'
-			) );
-			
-			return $mimes;
+		$mimes = array_merge( $mimes, array( 'xml' => 'application/xml' ) );
+
+		return $mimes;
 	}
 
 	/**

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -25,8 +25,11 @@ class WXR_Import_UI {
 	 *
 	 * @param array $mimes Already supported mime types.
 	 */
-	function add_mime_type_xml( $mimes ) {
-			$mimes = array_merge( $mimes, array( 'xml' => 'application/xml' ) );
+	public function add_mime_type_xml( $mimes ) {
+			$mimes = array_merge( $mimes, array(
+				'xml' => 'application/xml'
+			) );
+			
 			return $mimes;
 	}
 

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -16,6 +16,18 @@ class WXR_Import_UI {
 	public function __construct() {
 		add_action( 'wxr_importer.ui.header', array( $this, 'show_updates_in_header' ) );
 		add_action( 'admin_action_wxr-import-upload', array( $this, 'handle_async_upload' ) );
+		add_filter( 'upload_mimes', array( $this, 'add_mime_type_xml' ) );
+
+	}
+
+	/**
+	 * Add .xml files as supported format in the uploader.
+	 *
+	 * @param array $mimes Already supported mime types.
+	 */
+	function add_mime_type_xml( $mimes ) {
+			$mimes = array_merge( $mimes, array('xml' => 'application/xml') );
+			return $mimes;
 	}
 
 	/**

--- a/templates/import.php
+++ b/templates/import.php
@@ -34,7 +34,7 @@ $this->render_header();
 <div class="welcome-panel">
 	<div class="welcome-panel-content">
 		<h2><?php esc_html_e( 'Step 3: Importing', 'wordpress-importer' ) ?></h2>
-		<p id="import-status-message"><?php esc_html_e( 'Now importing.', 'wordpress-importer' ) ?></p>
+		<div id="import-status-message" class="notice notice-info"><?php esc_html_e( 'Now importing.', 'wordpress-importer' ) ?></div>
 
 		<table class="import-status">
 			<thead>

--- a/templates/import.php
+++ b/templates/import.php
@@ -24,10 +24,10 @@ $script_data = array(
 );
 
 $url = plugins_url( 'assets/import.js', dirname( __FILE__ ) );
-wp_enqueue_script( 'wxr-importer-import', $url, array( 'jquery' ), '20160412', true );
+wp_enqueue_script( 'wxr-importer-import', $url, array( 'jquery' ), '20160909', true );
 wp_localize_script( 'wxr-importer-import', 'wxrImportData', $script_data );
 
-wp_enqueue_style( 'wxr-importer-import', plugins_url( 'assets/import.css', dirname( __FILE__ ) ), array(), '20160412' );
+wp_enqueue_style( 'wxr-importer-import', plugins_url( 'assets/import.css', dirname( __FILE__ ) ), array(), '20160909' );
 
 $this->render_header();
 ?>


### PR DESCRIPTION
The notice box is more noticeable than before, following the WP standard notification box style:

![getting_query_params_resized](https://d17oy1vhnax1f7.cloudfront.net/items/350j3f2D1X0e2D0F2Y1d/Image%202016-09-10%20at%201.28.19%20AM.png?v=b7702a0a)
