### PR TITLE
Make the importer resumable

### DIFF
--- a/class-command.php
+++ b/class-command.php
@@ -16,6 +16,10 @@ class WXR_Import_Command extends WP_CLI_Command {
 	 *
 	 * [--default-author=<id>]
 	 * : Default author ID to use if invalid user is found in the import data.
+	 *
+	 * [--disable-fetch-attachments]
+	 * : Disable downloading external attachments.
+	 *
 	 */
 	public function import( $args, $assoc_args ) {
 		$logger = new WP_Importer_Logger_CLI();
@@ -34,7 +38,7 @@ class WXR_Import_Command extends WP_CLI_Command {
 		}
 
 		$options = array(
-			'fetch_attachments' => true,
+			'fetch_attachments' => empty( $assoc_args['disable-fetch-attachments'] ),
 		);
 		if ( isset( $assoc_args['default-author'] ) ) {
 			$options['default_author'] = absint( $assoc_args['default-author'] );

--- a/class-command.php
+++ b/class-command.php
@@ -16,10 +16,6 @@ class WXR_Import_Command extends WP_CLI_Command {
 	 *
 	 * [--default-author=<id>]
 	 * : Default author ID to use if invalid user is found in the import data.
-	 *
-	 * [--disable-fetch-attachments]
-	 * : Disable downloading external attachments.
-	 *
 	 */
 	public function import( $args, $assoc_args ) {
 		$logger = new WP_Importer_Logger_CLI();
@@ -38,7 +34,7 @@ class WXR_Import_Command extends WP_CLI_Command {
 		}
 
 		$options = array(
-			'fetch_attachments' => empty( $assoc_args['disable-fetch-attachments'] ),
+			'fetch_attachments' => true,
 		);
 		if ( isset( $assoc_args['default-author'] ) ) {
 			$options['default_author'] = absint( $assoc_args['default-author'] );

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -467,12 +467,22 @@ class WXR_Import_UI {
 		$mapping = $settings['mapping'];
 		$this->fetch_attachments = (bool) $settings['fetch_attachments'];
 
-		$importer = $this->get_importer();
-		if ( ! empty( $mapping['mapping'] ) ) {
-			$importer->set_user_mapping( $mapping['mapping'] );
-		}
-		if ( ! empty( $mapping['slug_overrides'] ) ) {
-			$importer->set_user_slug_overrides( $mapping['slug_overrides'] );
+		// Try to restore the importer from a previous run.
+		$importer = get_post_meta( $this->id, '_importer_state', true );
+
+		if ( ! is_a( $importer, 'WXR_Importer' ) ) {
+			$importer = $this->get_importer();
+			if ( ! empty( $mapping['mapping'] ) ) {
+				$importer->set_user_mapping( $mapping['mapping'] );
+			}
+			if ( ! empty( $mapping['slug_overrides'] ) ) {
+				$importer->set_user_slug_overrides( $mapping['slug_overrides'] );
+			}
+		} else {
+			$this->emit_sse_message( array(
+				'action' => 'resumed',
+				'node' => $importer->current_node,
+			) );
 		}
 
 		// Are we allowed to create users?

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -415,9 +415,6 @@ class WXR_Import_UI {
 		$settings = compact( 'mapping', 'fetch_attachments' );
 		update_post_meta( $this->id, '_wxr_import_settings', $settings );
 
-		// Time to run the import!
-		set_time_limit( 0 );
-
 		// Ensure we're not buffered.
 		wp_ob_end_flush_all();
 		flush();

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -506,23 +506,14 @@ class WXR_Import_UI {
 		flush();
 
 		$file = get_attached_file( $this->id );
-		$completed = false;
 		// Register a shutdown function to save the state of the importer
 		// if it didn't complete yet.
-		register_shutdown_function( function() use ( $importer, &$completed ) {
-			if ( true === $completed ) {
-				return;
-			}
-			update_post_meta( $this->id, '_importer_state', $importer );
-			$this->emit_sse_message( array(
-				'action' => 'paused',
-				'node' => $importer->current_node,
-			) );
-			exit;
-		});
+		$this->completed = false;
+		$this->importer = $importer;
+		register_shutdown_function( array( $this, 'pause_import' ) );
 
 		$err = $importer->import( $file );
-		$completed = true;
+		$this->completed = true;
 
 		// Remove the settings to stop future reconnects.
 		delete_post_meta( $this->id, '_wxr_import_settings' );
@@ -539,6 +530,23 @@ class WXR_Import_UI {
 
 		$this->emit_sse_message( $complete );
 		exit;
+	}
+
+	/**
+	 * Pause the importer.
+	 *
+	 * This is run on shutdown, to cause a pause and save of the import
+	 * progress if the importer did not complete yet.
+	 */
+	public function pause_import() {
+		if ( true === $this->completed ) {
+			return;
+		}
+		update_post_meta( $this->id, '_importer_state', $this->importer );
+		$this->emit_sse_message( array(
+			'action' => 'paused',
+			'node' => $importer->current_node,
+		) );
 	}
 
 	/**

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -208,7 +208,7 @@ class WXR_Import_UI {
 			$err = $this->handle_select( wp_unslash( $_REQUEST['id'] ) );
 
 			$previous_import = get_post_meta( $this->id, '_importer_state', true );
-			if ( $previous_import instanceof WXR_Importer ) ) {
+			if ( $previous_import instanceof WXR_Importer ) {
 				require __DIR__ . '/templates/resume-import.php';
 				return;
 			}
@@ -470,7 +470,7 @@ class WXR_Import_UI {
 		// Try to restore the importer from a previous run.
 		$importer = get_post_meta( $this->id, '_importer_state', true );
 
-		if ( ! $importer instanceof WXR_Importer ) ) {
+		if ( ! $importer instanceof WXR_Importer ) {
 			$importer = $this->get_importer();
 			if ( ! empty( $mapping['mapping'] ) ) {
 				$importer->set_user_mapping( $mapping['mapping'] );

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -206,6 +206,12 @@ class WXR_Import_UI {
 	protected function display_author_step() {
 		if ( isset( $_REQUEST['id'] ) ) {
 			$err = $this->handle_select( wp_unslash( $_REQUEST['id'] ) );
+
+			$previous_import = get_post_meta( $this->id, '_importer_state', true );
+			if ( is_a( $previous_import, 'WXR_Importer' ) ) {
+				require __DIR__ . '/templates/resume-import.php';
+				return;
+			}
 		} else {
 			$err = $this->handle_upload();
 		}

--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -208,7 +208,7 @@ class WXR_Import_UI {
 			$err = $this->handle_select( wp_unslash( $_REQUEST['id'] ) );
 
 			$previous_import = get_post_meta( $this->id, '_importer_state', true );
-			if ( is_a( $previous_import, 'WXR_Importer' ) ) {
+			if ( $previous_import instanceof WXR_Importer ) ) {
 				require __DIR__ . '/templates/resume-import.php';
 				return;
 			}
@@ -470,7 +470,7 @@ class WXR_Import_UI {
 		// Try to restore the importer from a previous run.
 		$importer = get_post_meta( $this->id, '_importer_state', true );
 
-		if ( ! is_a( $importer, 'WXR_Importer' ) ) {
+		if ( ! $importer instanceof WXR_Importer ) ) {
 			$importer = $this->get_importer();
 			if ( ! empty( $mapping['mapping'] ) ) {
 				$importer->set_user_mapping( $mapping['mapping'] );

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -343,15 +343,16 @@ class WXR_Importer extends WP_Importer {
 
 		// Start parsing!
 		while ( $reader->read() ) {
+			// Only deal with element opens
+			if ( $reader->nodeType !== XMLReader::ELEMENT ) {
+				continue;
+			}
+
 			$element_count++;
 			if ( $element_count < $this->current_node ) {
 				continue;
 			}
 			$this->current_node = $element_count;
-			// Only deal with element opens
-			if ( $reader->nodeType !== XMLReader::ELEMENT ) {
-				continue;
-			}
 
 			switch ( $reader->name ) {
 				case 'wp:wxr_version':

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -56,6 +56,8 @@ class WXR_Importer extends WP_Importer {
 	protected $url_remap = array();
 	protected $featured_images = array();
 
+	public $current_node = 0;
+
 	/**
 	 * Logger instance.
 	 *
@@ -337,9 +339,15 @@ class WXR_Importer extends WP_Importer {
 
 		// Reset other variables
 		$this->base_url = '';
+		$element_count = 0;
 
 		// Start parsing!
 		while ( $reader->read() ) {
+			$element_count++;
+			if ( $element_count < $this->current_node ) {
+				continue;
+			}
+			$this->current_node = $element_count;
 			// Only deal with element opens
 			if ( $reader->nodeType !== XMLReader::ELEMENT ) {
 				continue;

--- a/templates/resume-import.php
+++ b/templates/resume-import.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Resume the import.
+ */
+
+$this->render_header();
+
+$generator = $data->generator;
+if ( preg_match( '#^http://wordpress\.org/\?v=(\d+\.\d+\.\d+)$#', $generator, $matches ) ) {
+	$generator = sprintf( __( 'WordPress %s', 'wordpress-importer' ), $matches[1] );
+}
+
+?>
+<div class="welcome-panel">
+	<div class="welcome-panel-content">
+		<h2><?php esc_html_e( 'Resume Import', 'wordpress-importer' ) ?></h2>
+		<p><?php esc_html_e( 'We have detected this import can be resumed. Click Resume below, or chose to delete the partial import data.', 'wordpress-importer' ) ?></p>
+	</div>
+</div>
+
+<form action="<?php echo esc_url( $this->get_url( 2 ) ) ?>" method="post">
+	<input type="hidden" name="import_id" value="<?php echo esc_attr( $this->id ) ?>" />
+	<?php wp_nonce_field( sprintf( 'wxr.import:%d', $this->id ) ) ?>
+
+	<?php submit_button( __( 'Resume Import', 'wordpress-importer' ) ) ?>
+</form>
+
+<?php
+
+$this->render_footer();


### PR DESCRIPTION
Currently the importer runs a full everytime, which can be a big issue when there is a low execution time limit on the server. Instead, it would be great if the importer resued where it left off so it will function in all environments.
