### PR TITLE
Set $_GET[\'noheader\'] to string instead of bool

### DIFF
--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -90,7 +90,7 @@ class WXR_Import_UI {
 	 */
 	public function on_load() {
 		// Skip outputting the header on our import page, so we can handle it.
-		$_GET['noheader'] = true;
+		$_GET['noheader'] = 'true';
 	}
 
 	/**


### PR DESCRIPTION
This resolves issue #50 where WXR_Import_UI->on_load() should skip outputting the header on the import page so we can handle it in the import template. 