### PR TITLE
Check for path errors when running via CLI

### DIFF
--- a/class-command.php
+++ b/class-command.php
@@ -33,6 +33,11 @@ class WXR_Import_Command extends WP_CLI_Command {
 			}
 		}
 
+		$path = realpath( $args[0] );
+		if ( ! $path ) {
+			WP_CLI::error( sprintf( 'Specified file %s does not exist', $args[0] ) );
+		}
+
 		$options = array(
 			'fetch_attachments' => true,
 		);
@@ -45,7 +50,7 @@ class WXR_Import_Command extends WP_CLI_Command {
 		}
 		$importer = new WXR_Importer( $options );
 		$importer->set_logger( $logger );
-		$result = $importer->import( realpath( $args[0] ) );
+		$result = $importer->import( $path );
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
 		}

--- a/class-command.php
+++ b/class-command.php
@@ -45,6 +45,9 @@ class WXR_Import_Command extends WP_CLI_Command {
 		}
 		$importer = new WXR_Importer( $options );
 		$importer->set_logger( $logger );
-		$importer->import( realpath( $args[0] ) );
+		$result = $importer->import( realpath( $args[0] ) );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
 	}
 }


### PR DESCRIPTION
Fixes #98. `import()` gives us back a WP_Error that we should handle, but checking beforehand allows us to give a more specific error too.