### PR TITLE
Switch Travis CI to use Node.js v6 and Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: required
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: php
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
 
   - cd $TRAVIS_BUILD_DIR
-  - npm install -g npm
+  - nvm use 6
+  - node -v
+  - npm -v
   - npm install -g grunt-cli
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 
 language: php
@@ -34,6 +35,7 @@ before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
 
   - cd $TRAVIS_BUILD_DIR
+  - nvm install 6
   - nvm use 6
   - node -v
   - npm -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-sudo: required
+sudo: false
 
 language: php
 


### PR DESCRIPTION
The previous `npm install -g npm` is attempting to install npm v5 on Node.js v0.10.x which is unsupported, WordPress' _build tools_ are now based on the minimum Node.js version of v6.9.1

Switching to using the nvm alias via `nvm use 6` will currently use Node.js v6.10.3 and npm v3.10.10

This should allow the tests in #114 to be restarted and pass (except HHVM)