### PR TITLE
Match existing terms when possible.

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -917,8 +917,13 @@ class WXR_Importer extends WP_Importer {
 				$taxonomy = $term['taxonomy'];
 				$key = sha1( $taxonomy . ':' . $term['slug'] );
 
+				// Add terms that were processed earlier in WXR import.
 				if ( isset( $this->mapping['term'][ $key ] ) ) {
 					$term_ids[ $taxonomy ][] = (int) $this->mapping['term'][ $key ];
+				// Add terms that already exist on the site.
+				} else if ( $existing_term_id = $this->term_exists( $term ) ) {
+					$term_ids[ $taxonomy ][] = $existing_term_id;
+				// Add the term info as post meta for manual relinking.
 				} else {
 					$meta[] = array( 'key' => '_wxr_import_term', 'value' => $term );
 					$requires_remapping = true;


### PR DESCRIPTION
When importing posts to a site as part of a multi-part import process, it's possible that terms and posts will not be imported in the same run. When importing posts separately from term information, match the post's term data to terms that already exist on the site when possible.

This may be the issue in #110.

I'm currently working on a large and complicated migration and this new importer is really helping me out. Thanks for working on this!