### PR TITLE
Parsing <wp:postmeta> using an attribute-based/less-verbose XML structure

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1094,11 +1094,28 @@ class WXR_Importer extends WP_Importer {
 
 	/**
 	 * Parse a meta node into meta data.
+	 * Either parsed in its long format:
+	 * <wp:postmeta>
+	 *   <wp:meta_key>_thumbnail_id</wp:meta_key>
+	 *   <wp:meta_value><![CDATA[22328]]></wp:meta_value>
+	 * </wp:postmeta>
+	 *
+	 * Either provided in its short form
+	 * <wp:postmeta meta_key="_wp_page_template" meta_value="theme-custom-template.php" />
+	 *
+	 * Short form is only used if the node does NOT have child element
+	 *   and both meta_key and meta_value are set.
 	 *
 	 * @param DOMElement $node Parent node of meta data (typically `wp:postmeta` or `wp:commentmeta`).
 	 * @return array|null Meta data array on success, or null on error.
 	 */
 	protected function parse_meta_node( $node ) {
+		if ( ! $node->hasChildNodes()
+				 && ( $key = $node->getAttribute('meta_key') )
+				 && ( $value = $node->getAttribute('meta_value') ) ) {
+			return compact( 'key', 'value' );
+		}
+
 		foreach ( $node->childNodes as $child ) {
 			// We only care about child elements
 			if ( $child->nodeType !== XML_ELEMENT_NODE ) {


### PR DESCRIPTION
`<wp:postmeta>` is usually exported this way:
```
<wp:postmeta>
   <wp:meta_key>_wp_page_template</wp:meta_key>
   <wp:meta_value><![CDATA[some-string.tpl.php]]></wp:meta_value>
</wp:postmeta>
```
(156 bytes)

CDATA are used for the meta_value, so that HTML entities would not be interpreted by the XML parser.

This commit makes the parser aware of a second _short_ format where post's meta
 are expressed as attributes:
`<wp:postmeta meta_key="_wp_page_template" meta_value="some-string.tpl.php" />`
(85 bytes)


* In most case, none of meta_key and meta_value contain HTML entities.
* An exporter can perfectly define whether short form is ok for a given meta (entity presence, longtext `meta_value` length > X [XML does not set any limit on this btw])

ToDo: explore possible future use of `XMLReader::SUBST_ENTITIES` to completely avoid cluttering XML with CDATA?