### PR TITLE
Hook attach

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1040,9 +1040,12 @@ class WXR_Importer extends WP_Importer {
 			$remote_url = rtrim( $this->base_url, '/' ) . $remote_url;
 		}
 
-		$upload = $this->fetch_remote_file( $remote_url, $post );
-		if ( is_wp_error( $upload ) ) {
-			return $upload;
+		$upload = apply_filters( 'wxr_importer.process_attachment.uploaded', FALSE, $remote_url, $post, $meta);
+		if ( ! $upload )  {
+			$upload = $this->fetch_remote_file( $remote_url, $post );
+			if ( is_wp_error( $upload ) ) {
+				return $upload;
+			}
 		}
 
 		$info = wp_check_filetype( $upload['file'] );

--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1023,7 +1023,7 @@ class WXR_Importer extends WP_Importer {
 	protected function process_attachment( $post, $meta, $remote_url ) {
 		// try to use _wp_attached file for upload folder placement to ensure the same location as the export site
 		// e.g. location is 2003/05/image.jpg but the attachment post_date is 2010/09, see media_handle_upload()
-		$post['upload_date'] = $post['post_date'];
+		$post['upload_date'] = date('Y/m', strtotime($post['post_date']));
 		foreach ( $meta as $meta_item ) {
 			if ( $meta_item['key'] !== '_wp_attached_file' ) {
 				continue;


### PR DESCRIPTION
Provide a hook to allow developer omitting file download for whatever reason (like reusing already existing local directory).
Sample implementation of this hook:

```php
<?php


add_filter( 'wxr_importer.process_attachment.uploaded', function( $uploaded, $remote_url, $post, $meta ) {
    $filepath = wp_upload_dir()['basedir'] . '/' . $post['upload_date'] . '/' . basename( $remote_url );
    if ( file_exists( $filepath ) && ($filesize = filesize( $filepath ))) {
        $wp_url = wp_upload_dir()['baseurl'] . '/' . $post['upload_date'] . '/' . basename( $remote_url );
        $id = attachment_url_to_postid( $wp_url );
        if ( $id ) {
            $metadata = wp_get_attachment_metadata( $id );
            $metadata['url'] = $wp_url;
			printf(
				__( 'unmanaged media "%s" already registered (id: %d, %d bytes).', 'wordpress-importer' ) . PHP_EOL,
				$post['post_title'], $id, $filesize
			);
            return $metadata;
        } else {
			printf(
				__( 'unmanaged media "%s" already exists (%d bytes).', 'wordpress-importer' ) . PHP_EOL,
				$post['post_title'], $filesize
			);

            return [ 'file' => $filepath, 'url' => $wp_url ];
        }
    }
    return $uploaded;
}, 10, 4);
```
