### PR TITLE
Attachement is store to basename($url). urldecode() it

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1762,7 +1762,7 @@ class WXR_Importer extends WP_Importer {
 	 */
 	protected function fetch_remote_file( $url, $post ) {
 		// extract the file name and extension from the url
-		$file_name = basename( $url );
+		$file_name = basename( urldecode( $url ) );
 
 		// get placeholder file in the upload dir with a unique, sanitized filename
 		$upload = wp_upload_bits( $file_name, 0, '', $post['upload_date'] );


### PR DESCRIPTION
Attachement is fetched to basename($url). $url comes from either attachment_url or guid.
Assume that it may be urlencode so that "%20" in the URL will end up as space (as in the original system) rather than plain "20".