### PR TITLE
actually catch wp_insert_attachment errors

### DIFF
--- a/class-wxr-importer.php
+++ b/class-wxr-importer.php
@@ -1059,7 +1059,7 @@ class WXR_Importer extends WP_Importer {
 		}
 
 		// as per wp-admin/includes/upload.php
-		$post_id = wp_insert_attachment( $post, $upload['file'] );
+		$post_id = wp_insert_attachment( $post, $upload['file'], 0, TRUE );
 		if ( is_wp_error( $post_id ) ) {
 			return $post_id;
 		}


### PR DESCRIPTION
`wp_insert_attachment()` returns 0 **unless** the 4th parameter is set to TRUE in order to return a `WP_Error` (since 4.7.0)
https://core.trac.wordpress.org/browser/tags/4.9.5/src/wp-includes/post.php#L4898