### PR TITLE
Fix EventSources charset error

### DIFF
--- a/class-wxr-import-ui.php
+++ b/class-wxr-import-ui.php
@@ -441,7 +441,7 @@ class WXR_Import_UI {
 		}
 
 		// Start the event stream.
-		header( 'Content-Type: text/event-stream' );
+		header( 'Content-Type: text/event-stream, charset=UTF-8' );
 
 		$this->id = wp_unslash( (int) $_REQUEST['id'] );
 		$settings = get_post_meta( $this->id, '_wxr_import_settings', true );


### PR DESCRIPTION
EventSource aborting the connection due to below error.

`EventSource's response has a charset ("iso-8859-1") that is not UTF-8. Aborting the connection.`