### PR TITLE
Make the styles not broken in 6.2

### DIFF
--- a/assets/import.css
+++ b/assets/import.css
@@ -48,3 +48,17 @@
 	line-height: 40px;
 	margin: 20px 0;
 }
+
+.welcome-panel
+.welcome-panel h2 {
+	color: #f2f2f2;
+}
+
+.welcome-panel h2 .notice {
+	color: #3c434a;
+}
+
+.welcome-panel-content {
+	padding: 0 15px;
+}
+	


### PR DESCRIPTION
The `.welcome-panel` class gets some new styling in 6.2 which makes the text virtually unreadable (black on dark blue). This PR flips the colors and adds some padding. Have not tested to see if these styles are enqueued globally but I don't _think_ they are (looks like they're just [here](https://github.com/humanmade/WordPress-Importer/blob/master/templates/import.php)), but if this does affect things outside the importing page, a class could be added to the [`welcome-panel` div](https://github.com/humanmade/WordPress-Importer/blob/master/templates/import.php#L34) wrapper to specify that it's a `wp-import welcome-panel` and then these CSS rules could be applied to `wp-import.welcome-panel` or just `wp-import`.