### PR TITLE
Update composer.json to use PHPCS Standards package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "dev-master",
-		"squizlabs/php_codesniffer": "~2.9",
+		"phpcsstandards/php_codesniffer": "~2.9",
 		"fig-r/psr2r-sniffer": "~0.4"
 	},
 	"autoload"          : { },


### PR DESCRIPTION
Removes abandoned Squizlabs package and instead uses the new PHPCS Standards org package